### PR TITLE
any? is not the opposite of empty?

### DIFF
--- a/lib/i18n_routable/generating/localizable_url_helper.rb
+++ b/lib/i18n_routable/generating/localizable_url_helper.rb
@@ -15,7 +15,7 @@ module I18nRoutable
           def #{selector}(*args)
             options =  #{hash_access_method}(args.extract_options!)
 
-            if args.any?
+            unless args.empty?
               options[:_positional_args] = args
               options[:_positional_keys] = #{positional_segments.inspect}
             end


### PR DESCRIPTION
Update `:_positional_args` if there are any rather than iterating over the args with `any?` strangely.
